### PR TITLE
Fix permissions

### DIFF
--- a/website/misc/login_functions.py
+++ b/website/misc/login_functions.py
@@ -36,8 +36,6 @@ class User(flask_login.UserMixin):
             self.password = user.password
             self.salt = user.salt
             self.phone_number = user.phone_number
-            self.authorized = user.authorized
-            self.admin = user.admin
         return
 
     @classmethod
@@ -49,11 +47,25 @@ class User(flask_login.UserMixin):
 
     @property
     def is_admin(self):
-        return self.admin
+        try:
+            models.Permission.select().join(models.PermissionType).switch(models.Permission).join(models.User).where(
+                    (models.PermissionType.name == 'admin') & (models.User.login_name == self.login_name)
+            ).get()
+        except peewee.DoesNotExist:
+            return False
+        else:
+            return True
 
     @property
     def is_authorized(self):
-        return self.authorized
+        try:
+            models.Permission.select().join(models.PermissionType).switch(models.Permission).join(models.User).where(
+                    (models.PermissionType.name == 'authorized') & (models.User.login_name == self.login_name)
+            ).get()
+        except peewee.DoesNotExist:
+            return False
+        else:
+            return True
 
 
 @login_manager.user_loader

--- a/website/misc/login_functions.py
+++ b/website/misc/login_functions.py
@@ -45,28 +45,19 @@ class User(flask_login.UserMixin):
         except LookupError:
             return None
 
-    @property
-    def is_admin(self):
+# Add the is_ property for all the permission types
+for p_type in models.PermissionType.select():
+    def func(self):
         try:
             models.Permission.select().join(models.PermissionType).switch(models.Permission).join(models.User).where(
-                    (models.PermissionType.name == 'admin') & (models.User.login_name == self.login_name)
+                    (models.PermissionType.name == p_type.name) & (models.User.login_name == self.login_name)
             ).get()
         except peewee.DoesNotExist:
             return False
         else:
             return True
-
-    @property
-    def is_authorized(self):
-        try:
-            models.Permission.select().join(models.PermissionType).switch(models.Permission).join(models.User).where(
-                    (models.PermissionType.name == 'authorized') & (models.User.login_name == self.login_name)
-            ).get()
-        except peewee.DoesNotExist:
-            return False
-        else:
-            return True
-
+    prop_func = property(func)
+    setattr(User, 'is_' + p_type.name, prop_func)
 
 @login_manager.user_loader
 def load_user(login_name):

--- a/website/models.py
+++ b/website/models.py
@@ -89,6 +89,16 @@ class EventUser(BaseModel):
     invitee = peewee.ForeignKeyField(User)
 
 
+class PermissionType(BaseModel):
+    name = peewee.CharField(unique=True)
+    description = peewee.CharField(max_length=4096)
+
+
+class Permission(BaseModel):
+    user = peewee.ForeignKeyField(User, related_name='permissions')
+    permission = peewee.ForeignKeyField(PermissionType, related_name='permitted_users')
+
+
 # -----------Helper functions-----------
 def before_request_handler(database=db):
     logger.debug('Opening connection to DB')
@@ -126,11 +136,17 @@ def find_tables(base=BaseModel):
     return subclasses + sub_subclasses
 
 
+def add_necessary_data():
+    PermissionType.get_or_create(name='authorized', description="A user who is authorized to use the site")
+    PermissionType.get_or_create(name='admin', description="A user who has admin privileges, or manages authorized users")
+
+
 if __name__ == '__main__':
     import datetime
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s : %(name)s : %(levelname)s : %(message)s')
     before_request_handler()
     create_tables()
+    add_necessary_data()
 
     def fill_tables_with_dummy_data():
         # -----Electricity-----

--- a/website/models.py
+++ b/website/models.py
@@ -80,8 +80,6 @@ class User(Invitee):
     password = peewee.FixedCharField(max_length=64)
     salt = peewee.FixedCharField(max_length=32)  # This should be half the password max length
     email_me = peewee.BooleanField(default=True)
-    authorized = peewee.BooleanField(default=False)
-    admin = peewee.BooleanField(default=False)
 
 
 class EventUser(BaseModel):
@@ -140,6 +138,9 @@ def add_necessary_data():
     PermissionType.get_or_create(name='authorized', description="A user who is authorized to use the site")
     PermissionType.get_or_create(name='admin', description="A user who has admin privileges, or manages authorized users")
 
+
+# Global
+PERMISSION_TYPE = {p.name: p for p in PermissionType.select()}
 
 if __name__ == '__main__':
     import datetime
@@ -276,10 +277,11 @@ if __name__ == '__main__':
                       salt=salt.decode(),
                       password=password,
                       email_me=False,
-                      email="test@test.info",
-                      authorized=True,
-                      admin=True)
+                      email="test@test.info")
         user_1.save()
+        Permission(user=user_1, permission=PERMISSION_TYPE['admin']).save()
+        Permission(user=user_1, permission=PERMISSION_TYPE['authorized']).save()
+
         salt = base64.b64encode(os.urandom(32))
         password = hashlib.sha256('password2'.encode() + salt).hexdigest()
         user_2 = User(name='User 2',
@@ -288,9 +290,10 @@ if __name__ == '__main__':
                       password=password,
                       email_me=False,
                       email="test2@test.info",
-                      phone_number='234-5678',
-                      authorized=True)
+                      phone_number='234-5678')
         user_2.save()
+        Permission(user=user_2, permission=PERMISSION_TYPE['authorized']).save()
+
         salt = base64.b64encode(os.urandom(32))
         password = hashlib.sha256('password3'.encode() + salt).hexdigest()
         user_3 = User(name='User 3',
@@ -299,9 +302,10 @@ if __name__ == '__main__':
                       password=password,
                       email_me=True,
                       email="test3@test.moe",
-                      phone_number='234-5678',
-                      authorized=True)
+                      phone_number='234-5678')
         user_3.save()
+        Permission(user=user_3, permission=PERMISSION_TYPE['authorized']).save()
+
         salt = base64.b64encode(os.urandom(32))
         password = hashlib.sha256('password4'.encode() + salt).hexdigest()
         user_4 = User(name='User 4',

--- a/website/models.py
+++ b/website/models.py
@@ -112,8 +112,18 @@ atexit.register(after_request_handler, db)
 
 def create_tables():
     before_request_handler(db)
-    db.create_tables([Electricity, Event, Todo, Bill, Invitee, EventInvitee, User, EventUser], True)
+    db.create_tables(find_tables(), True)
     return
+
+
+def find_tables(base=BaseModel):
+    """Find all tables that inherit from the given table including sub-sub
+    base: class: teh table root to start with"""
+    subclasses = base.__subclasses__()
+    if not subclasses:
+        return subclasses
+    sub_subclasses = [item for subclass in subclasses for item in find_tables(subclass)]
+    return subclasses + sub_subclasses
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR changes how the site handles permissions.

Prior, All permissions were a column on the User table. This was not ideal because if a new permission was to be added, a new column would have to be added to the User table.

Now all permissions are handled with two tables. One is a permission type table that defines what permissions are possible, and a permission table that links a user to a permission. This is much more extensible as it allows new permissions to be added without modifying any table.

The login manager now also adds the is_ permission property dynamically based off of the table.

Solves issue #25 
